### PR TITLE
fix intro behavior

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:restoreAnyVersion="true"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        tools:ignore="GoogleAppIndexingWarning" >
+        tools:ignore="GoogleAppIndexingWarning"
+        android:allowBackup="false" >
         <meta-data
             android:name="android.max_aspect"
             android:value="ratio_float" />

--- a/app/src/main/java/io/lerk/lrkFM/LrkFMApp.java
+++ b/app/src/main/java/io/lerk/lrkFM/LrkFMApp.java
@@ -1,11 +1,11 @@
 package io.lerk.lrkFM;
 
+import android.app.Application;
 import android.content.Context;
-import android.support.multidex.MultiDexApplication;
 
 import java.lang.ref.WeakReference;
 
-public class LrkFMApp extends MultiDexApplication {
+public class LrkFMApp extends Application {
 
     public static final String CHANNEL_ID = "lrkFM";
     private static WeakReference<Context> context;

--- a/app/src/main/java/io/lerk/lrkFM/PrefUtils.java
+++ b/app/src/main/java/io/lerk/lrkFM/PrefUtils.java
@@ -78,7 +78,7 @@ public class PrefUtils<T> {
         if (context != null) {
             try {
                 if (type.equals(Boolean.class)) {
-                    return (T) returnBooleanValueCheckForDebug();
+                    return (T) Boolean.valueOf(preferences.getBoolean(key, (Boolean) preference.getDefaultValue()));
                 } else if (type.equals(String.class)) {
                     return (T) preferences.getString(key, (String) preference.getDefaultValue());
                 } else if (type.equals(HashSet.class)) {
@@ -91,20 +91,6 @@ public class PrefUtils<T> {
             Log.e(TAG, "Unable to get preference: context is null!");
         }
         return null;
-    }
-
-    /**
-     * Returns the value of a {@link Boolean} preference but also checks for {@link BuildConfig#DEBUG} and returns other values in this case.
-     * @return The preference value
-     */
-    private Boolean returnBooleanValueCheckForDebug() {
-        if (BuildConfig.DEBUG) {
-            if(preference.equals(PreferenceEntity.FIRST_START)) {
-                return Boolean.TRUE; // In debug, every start is a firstStart
-            }
-        }
-        // return the actual value
-        return preferences.getBoolean(key, (Boolean) preference.getDefaultValue());
     }
 
     /**

--- a/app/src/main/java/io/lerk/lrkFM/activities/IntroActivity.java
+++ b/app/src/main/java/io/lerk/lrkFM/activities/IntroActivity.java
@@ -29,9 +29,6 @@ public class IntroActivity extends ThemedAppCompatActivity {
      */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        if(new PrefUtils<Boolean>(PreferenceEntity.FIRST_START).getValue() || new PrefUtils<Boolean>(PreferenceEntity.ALWAYS_SHOW_INTRO).getValue()) {
-            launchMainAndFinish(savedInstanceState);
-        }
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_intro);
         Toolbar toolbar = findViewById(R.id.toolbar);

--- a/app/src/main/java/io/lerk/lrkFM/activities/file/FileActivity.java
+++ b/app/src/main/java/io/lerk/lrkFM/activities/file/FileActivity.java
@@ -88,6 +88,7 @@ import static io.lerk.lrkFM.consts.Operation.EXTRACT;
 import static io.lerk.lrkFM.consts.Operation.MOVE;
 import static io.lerk.lrkFM.consts.Operation.NONE;
 import static io.lerk.lrkFM.consts.PreferenceEntity.ALWAYS_EXTRACT_IN_CURRENT_DIR;
+import static io.lerk.lrkFM.consts.PreferenceEntity.ALWAYS_SHOW_INTRO;
 import static io.lerk.lrkFM.consts.PreferenceEntity.BOOKMARKS;
 import static io.lerk.lrkFM.consts.PreferenceEntity.BOOKMARK_CURRENT_FOLDER;
 import static io.lerk.lrkFM.consts.PreferenceEntity.BOOKMARK_EDIT_MODE;
@@ -318,10 +319,9 @@ public class FileActivity extends ThemedAppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        PrefUtils<Boolean> firstStartPref = new PrefUtils<>(FIRST_START);
         if (getIntent().hasExtra(FIRST_START_EXTRA) && getIntent().getBooleanExtra(FIRST_START_EXTRA, false)) {
-            firstStartPref.setValue(false);
-        } else if (firstStartPref.getValue()) {
+            new PrefUtils<Boolean>(FIRST_START).setValue(false);
+        } else if (new PrefUtils<Boolean>(FIRST_START).getValue() || new PrefUtils<Boolean>(ALWAYS_SHOW_INTRO).getValue()) {
             startActivity(new Intent(this, IntroActivity.class));
             finish();
         }
@@ -1122,7 +1122,7 @@ public class FileActivity extends ThemedAppCompatActivity {
      */
     private void launchBugReportTab() {
         CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
-        builder.setToolbarColor(getColor(R.color.default_primary));
+        builder.setToolbarColor(getColorByAttr(R.attr.colorPrimary));
         CustomTabsIntent build = builder.build();
         build.launchUrl(this, Uri.parse("https://github.com/lfuelling/lrkFM/issues/new"));
     }


### PR DESCRIPTION
This PR fixes the current intro behavior. The application uses the `FileActivity` class instead of the `IntroActivity` since the last version. 

The code for checking for the first start was still in `IntroActivity`.